### PR TITLE
Fixed undefined reference g_thread_init

### DIFF
--- a/bot2-frames/src/renderer/CMakeLists.txt
+++ b/bot2-frames/src/renderer/CMakeLists.txt
@@ -34,6 +34,7 @@ pods_install_pkg_config_file(bot2-frames-renderers
 #build the test-viewer
 add_executable(test-viewer test_viewer.c)
 target_link_libraries(test-viewer ${GLUT_LIBRARIES})
+target_link_libraries(test-viewer gthread-2.0)
 pods_use_pkg_config_packages(test-viewer 
                                          bot2-vis 
                                          bot2-lcmgl-renderer 

--- a/bot2-lcmgl/src/lcmgl-viewer/CMakeLists.txt
+++ b/bot2-lcmgl/src/lcmgl-viewer/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(bot-lcmgl-viewer
     view_menu.c
     )
 
+target_link_libraries(bot-lcmgl-viewer gthread-2.0)
+
 pods_use_pkg_config_packages(bot-lcmgl-viewer bot2-vis bot2-lcmgl-renderer)
 
 

--- a/bot2-vis/src/rwx-viewer/CMakeLists.txt
+++ b/bot2-vis/src/rwx-viewer/CMakeLists.txt
@@ -4,6 +4,8 @@ add_executable(bot-rwx-viewer
     main.c
     renderer_rwx.c)
 
+target_link_libraries(bot-rwx-viewer gthread-2.0)
+
 pods_use_pkg_config_packages(bot-rwx-viewer bot2-vis)
 
 pods_install_executables(bot-rwx-viewer)

--- a/bot2-vis/src/wavefront-viewer/CMakeLists.txt
+++ b/bot2-vis/src/wavefront-viewer/CMakeLists.txt
@@ -4,6 +4,8 @@ add_executable(bot-wavefront-viewer
     main.c
     renderer_wavefront.c)
 
+target_link_libraries(bot-wavefront-viewer gthread-2.0)
+
 pods_use_pkg_config_packages(bot-wavefront-viewer bot2-vis)
 
 pods_install_executables(bot-wavefront-viewer)


### PR DESCRIPTION
I ran into an linking error undefined reference to `g_thread_init` when building on Ubuntu 16.04

Adding `target_link_libraries(thetarget gthread-2.0)` to the relevant CMakeLists.txt files fixes this. This is based on advice from here https://bugs.launchpad.net/shardbridge/+bug/1119471 where they suggested adding the `-lgthread-2.0` flag. 